### PR TITLE
[TravisCI] Removing nightly travis-ci build as broken

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea/
 /vendor/
 composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ php:
   - '5.6'
   - '7.0'
   - '7.1'
-  - 'nightly'
+  - '7.2'
+  - '7.3'
 install:
   - composer install
 script:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.org/danbelden/php-siren.svg?branch=master)](https://travis-ci.org/danbelden/php-siren)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/danbelden/php-siren/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/danbelden/php-siren/?branch=master)
+[![Maintainability](https://api.codeclimate.com/v1/badges/6fb500c415e1e62a37b5/maintainability)](https://codeclimate.com/github/danbelden/php-siren/maintainability)
 [![Latest Stable Version](https://poser.pugx.org/danbelden/php-siren/version.svg)](https://packagist.org/packages/danbelden/php-siren)
 [![Total Downloads](https://poser.pugx.org/danbelden/php-siren/downloads.svg)](https://packagist.org/packages/danbelden/php-siren)
 


### PR DESCRIPTION
- https://travis-ci.org/danbelden/php-siren/jobs/494387473

```
$ composer install
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 19 installs, 0 updates, 0 removals
  - Installing symfony/polyfill-ctype (v1.10.0): Downloading (100%)
  - Installing symfony/yaml (v2.8.49): Downloading (100%)
  - Installing sebastian/version (1.0.6): Downloading (100%)
  - Installing sebastian/global-state (1.1.1): Downloading (100%)
  - Installing sebastian/recursion-context (1.0.5): Downloading (100%)
  - Installing sebastian/exporter (1.2.2): Downloading (100%)
  - Installing sebastian/environment (1.3.8): Downloading (100%)
  - Installing sebastian/diff (1.4.3): Downloading (100%)
  - Installing sebastian/comparator (1.2.4): Downloading (100%)
  - Installing doctrine/instantiator (1.0.5): Downloading (100%)
  - Installing phpunit/php-text-template (1.2.1): Downloading (100%)
  - Installing phpunit/phpunit-mock-objects (2.3.8): Downloading (100%)
  - Installing phpunit/php-timer (1.0.9): Downloading (100%)
  - Installing phpunit/php-file-iterator (1.4.5): Downloading (100%)
  - Installing phpunit/php-token-stream (1.4.12): Downloading (100%)
  - Installing phpunit/php-code-coverage (2.2.4): Downloading (100%)
  - Installing phpdocumentor/reflection-docblock (2.0.5): Downloading (100%)
  - Installing phpspec/prophecy (1.8.0): Downloading (100%)
  - Installing phpunit/phpunit (4.8.36): Downloading (100%)
sebastian/global-state suggests installing ext-uopz (*)
phpunit/php-code-coverage suggests installing ext-xdebug (>=2.2.1)
phpdocumentor/reflection-docblock suggests installing dflydev/markdown (~1.0)
phpdocumentor/reflection-docblock suggests installing erusev/parsedown (~1.0)
phpunit/phpunit suggests installing phpunit/php-invoker (~1.1)
Package phpunit/phpunit-mock-objects is abandoned, you should avoid using it. No replacement was suggested.
Writing lock file
Generating autoload files
0.09s$ vendor/bin/phpunit
PHP Fatal error:  Uncaught Error: Call to undefined function each() in /home/travis/build/danbelden/php-siren/vendor/phpunit/phpunit/src/Util/Getopt.php:38
Stack trace:
#0 /home/travis/build/danbelden/php-siren/vendor/phpunit/phpunit/src/TextUI/Command.php(240): PHPUnit_Util_Getopt::getopt(Array, 'd:c:hv', Array)
#1 /home/travis/build/danbelden/php-siren/vendor/phpunit/phpunit/src/TextUI/Command.php(111): PHPUnit_TextUI_Command->handleArguments(Array)
#2 /home/travis/build/danbelden/php-siren/vendor/phpunit/phpunit/src/TextUI/Command.php(100): PHPUnit_TextUI_Command->run(Array, true)
#3 /home/travis/build/danbelden/php-siren/vendor/phpunit/phpunit/phpunit(52): PHPUnit_TextUI_Command::main()
#4 {main}
  thrown in /home/travis/build/danbelden/php-siren/vendor/phpunit/phpunit/src/Util/Getopt.php on line 38
```