### PR TITLE
[TravisCI] Verbosely fix travis build errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,24 @@
 language: php
-php:
-  - '5.4'
-  - '5.5'
-  - '5.6'
-  - '7.0'
-  - '7.1'
-  - '7.2'
-  - '7.3'
+matrix:
+  include:
+    - php: 5.2
+      dist: precise
+    - php: 5.3
+      dist: precise
+    - php: '5.4'
+      dist: trusty
+    - php: '5.5'
+      dist: trusty
+    - php: '5.6'
+      dist: trusty
+    - php: '7.0'
+      dist: trusty
+    - php: '7.1'
+      dist: trusty
+    - php: '7.2'
+      dist: trusty
+    - php: '7.3'
+      dist: trusty
 install:
   - composer install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,19 +3,19 @@ matrix:
   include:
     - php: 5.3
       dist: precise
-    - php: '5.4'
+    - php: 5.4
       dist: trusty
-    - php: '5.5'
+    - php: 5.5
       dist: trusty
-    - php: '5.6'
+    - php: 5.6
       dist: trusty
-    - php: '7.0'
+    - php: 7.0
       dist: trusty
-    - php: '7.1'
+    - php: 7.1
       dist: trusty
-    - php: '7.2'
+    - php: 7.2
       dist: trusty
-    - php: '7.3'
+    - php: 7.3
       dist: trusty
 install:
   - composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 matrix:
   include:
-    - php: 5.2
-      dist: precise
     - php: 5.3
       dist: precise
     - php: '5.4'


### PR DESCRIPTION
## Overview

- https://travis-ci.org/danbelden/php-siren/builds/552044659

```
$ git clone --depth=50 --branch=master https://github.com/danbelden/php-siren.git danbelden/php-siren
Cloning into 'danbelden/php-siren'...
remote: Enumerating objects: 2, done.
remote: Counting objects: 100% (2/2), done.
remote: Compressing objects: 100% (2/2), done.
remote: Total 99 (delta 0), reused 2 (delta 0), pack-reused 97
Receiving objects: 100% (99/99), 27.63 KiB | 3.07 MiB/s, done.
Resolving deltas: 100% (53/53), done.
$ cd danbelden/php-siren
$ git checkout -qf 284399cae4edea7191b98beed842cc33947f9ce6
0.02s$ phpenv global 5.4 2>/dev/null
5.4 is not pre-installed; installing
Downloading archive: https://storage.googleapis.com/travis-ci-language-archives/php/binaries/ubuntu/16.04/x86_64/php-5.4.tar.bz2
0.12s$ curl -s -o archive.tar.bz2 $archive_url && tar xjf archive.tar.bz2 --directory /
bzip2: (stdin) is not a bzip2 file.
tar: Child returned status 2
tar: Error is not recoverable: exiting now
0.00s0.02s$ phpenv global 5.4
rbenv: version `5.4' not installed
The command "phpenv global 5.4" failed and exited with 1 during .
```